### PR TITLE
Live reload implementation

### DIFF
--- a/MongoDb.Asp.ConfigurationProvider/ConfigReadOption.cs
+++ b/MongoDb.Asp.ConfigurationProvider/ConfigReadOption.cs
@@ -1,6 +1,6 @@
 ﻿namespace MongoDb.Asp.ConfigurationProvider
 {
-    internal enum ConfigReadOption
+    public enum ConfigReadOption
     {
         ReadAll = 0,
         DefinedKeys = 1,

--- a/MongoDb.Asp.ConfigurationProvider/MongoDb.Asp.ConfigurationProvider.csproj
+++ b/MongoDb.Asp.ConfigurationProvider/MongoDb.Asp.ConfigurationProvider.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.1.1</Version>
     <Authors>Vineet Yadav, Marius Schiffer</Authors>
     <Company></Company>
     <Description>Configuration provider for mongo db. Can read runtime configuration from defined mongo db database / collection.

--- a/MongoDb.Asp.ConfigurationProvider/MongoDb.Asp.ConfigurationProvider.csproj
+++ b/MongoDb.Asp.ConfigurationProvider/MongoDb.Asp.ConfigurationProvider.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>3.0.0</Version>
-    <Authors>Vineet Yadav</Authors>
+    <Version>3.1.0</Version>
+    <Authors>Vineet Yadav, Marius Schiffer</Authors>
     <Company></Company>
     <Description>Configuration provider for mongo db. Can read runtime configuration from defined mongo db database / collection.
 Refer: https://github.com/yadavvineet/MongoDb.Asp.ConfigurationProvider for more details</Description>
     <Copyright>Vineet Yadav</Copyright>
-    <PackageProjectUrl>https://github.com/yadavvineet/MongoDb.Asp.ConfigurationProvider</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/yadavvineet/MongoDb.Asp.ConfigurationProvider</RepositoryUrl>
+    <PackageProjectUrl>https://gitlab.com/MariusSchiffer/MongoDb-Asp-ConfigurationProvider</PackageProjectUrl>
+    <RepositoryUrl>https://gitlab.com/MariusSchiffer/MongoDb-Asp-ConfigurationProvider</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression></PackageLicenseExpression>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>

--- a/MongoDb.Asp.ConfigurationProvider/MongoDbConfigOptions.cs
+++ b/MongoDb.Asp.ConfigurationProvider/MongoDbConfigOptions.cs
@@ -2,14 +2,16 @@
 {
     public sealed class MongoDbConfigOptions
     {
-        internal string ConnectionString { get; }
-        internal string DatabaseName { get; }
-        internal string CollectionName { get; }
-        internal string[] KeysToRead { get; }
-        internal ConfigReadOption ReadOption { get; }
-        internal bool QueryInFilteredMode { get; set; }
-        internal string KeyToQuery { get; set; }
-        internal object ValueToMatch { get; set; }
+        public string ConnectionString { get; set; }
+        public string DatabaseName { get; set; }
+        public string CollectionName { get; set; }
+        public string[] KeysToRead { get; set; }
+        public ConfigReadOption ReadOption { get; set; }
+        public bool QueryInFilteredMode { get; set; }
+        public string KeyToQuery { get; set; }
+        public object ValueToMatch { get; set; }
+
+        public bool LiveReload { get; set; }
 
         private MongoDbConfigOptions(string connectionString, string databaseName, string collectionName)
         {

--- a/MongoDb.Asp.ConfigurationProvider/MongoDbConfigurationProvider.cs
+++ b/MongoDb.Asp.ConfigurationProvider/MongoDbConfigurationProvider.cs
@@ -7,9 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 
 namespace MongoDb.Asp.ConfigurationProvider
 {

--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@
 
 1. Install the nuget package: 
 
+   Add GitLab source for this repo:
+
    ```c#
-   Install-Package MongoDb.Asp.ConfigurationProvider
+   Install-Package -Source "https://gitlab.com/api/v4/projects/27995356/packages/nuget/index.json" MongoDb.Asp.ConfigurationProvider
    ```
 
    

--- a/TestWebApp/Controllers/HomeController.cs
+++ b/TestWebApp/Controllers/HomeController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Diagnostics;
+using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using TestWebApp.Models;
 
@@ -8,15 +10,17 @@ namespace TestWebApp.Controllers
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly IConfiguration _configuration;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, IConfiguration configuration)
         {
             _logger = logger;
+            _configuration = configuration;
         }
 
         public IActionResult Index()
         {
-            return View();
+            return View(_configuration.GetChildren());
         }
 
         public IActionResult Privacy()

--- a/TestWebApp/Program.cs
+++ b/TestWebApp/Program.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
@@ -22,9 +23,10 @@ namespace TestWebApp
 
         private static void ConfigureMongoConfiguration(HostBuilderContext arg1, IConfigurationBuilder configurationBuilder)
         {
+            var url = Environment.GetEnvironmentVariable("MONGO_URL");
             configurationBuilder.AddMongoDbConfiguration(MongoDbConfigOptions.GetOptionsForAllKeysAllDocuments(
-                @"mongodb://<CONNECTION_STRING>",
-                "myconfigdb", "settings"));
+                url,
+                "server", "settings"));
 
             //configurationBuilder.AddMongoDbConfiguration(MongoDbConfigOptions.GetOptionsForDefinedKeysAllDocuments(
             //    @"mongodb://<CONNECTION_STRING>",
@@ -33,9 +35,9 @@ namespace TestWebApp
             //configurationBuilder.AddMongoDbConfiguration(MongoDbConfigOptions.GetOptionsForAllKeysFilteredDocuments(
             //    @"mongodb://<CONNECTION_STRING>",
             //    "myconfigdb", "settings", "environment", "qa"));
-            configurationBuilder.AddMongoDbConfiguration(MongoDbConfigOptions.GetOptionsForDefinedKeysFilteredDocument(
-                @"mongodb://<CONNECTION_STRING>",
-                "myconfigdb", "settings", "environment", "dev", "key1", "key2", "key9"));
+            //configurationBuilder.AddMongoDbConfiguration(MongoDbConfigOptions.GetOptionsForDefinedKeysFilteredDocument(
+            //    @"mongodb://<CONNECTION_STRING>",
+            //    "myconfigdb", "settings", "environment", "dev", "key1", "key2", "key9"));
         }
     }
 }

--- a/TestWebApp/Properties/launchSettings.json
+++ b/TestWebApp/Properties/launchSettings.json
@@ -20,7 +20,8 @@
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "MONGO_URL": "mongodb://localhost:27017/server"
       }
     }
   }

--- a/TestWebApp/Startup.cs
+++ b/TestWebApp/Startup.cs
@@ -18,7 +18,7 @@ namespace TestWebApp
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-           
+            services.AddSingleton<IConfiguration>(Configuration);
             services.AddControllersWithViews();
         }
 

--- a/TestWebApp/Views/Home/Index.cshtml
+++ b/TestWebApp/Views/Home/Index.cshtml
@@ -1,8 +1,20 @@
-﻿@{
+﻿@using Microsoft.Extensions.Configuration
+@using System.Collections.Specialized
+@using MongoDB.Bson
+@model IEnumerable<IConfigurationSection>
+@{
     ViewData["Title"] = "Home Page";
 }
 
 <div class="text-center">
-    <h1 class="display-4">Welcome</h1>
-    <p>Learn about <a href="https://docs.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+    <h1 class="display-4">Configuration</h1>
+    <table>
+    @foreach (var sec in Model)
+    {
+        <tr>
+            <td>@sec.Key</td>
+            <td>@sec.Value</td>
+        </tr>
+    }
+    </table>
 </div>


### PR DESCRIPTION
This is a PoC for live-reload. Uses changestreams for watching. If the collection changes, it triggers the reload first, then starts the watch process again. I also extended the TestWebApp a bit for this.

Needs a MongoDB instance with Replset (see here https://docs.mongodb.com/manual/tutorial/convert-standalone-to-replica-set/ )

I'm not sure on how to add a good config option if this should be enabled (as it cannot be enabled on standalone non-replset MongoDB servers, maybe this should also be checked or be caught)

IMO parts of the ConfigOptions object should be mutable from the outside. In my use case the database name is already in the URL, giving it is redundant.

What do you think?